### PR TITLE
fix: handle nested project bpmn files

### DIFF
--- a/ide-bpm/scripts/app.js
+++ b/ide-bpm/scripts/app.js
@@ -108,7 +108,7 @@ flowableModeler
             templateUrl: 'views/app-definition.html',
             controller: 'AppDefinitionCtrl'
         })
-        .when('/editor/:workspace/:project/:path', {
+        .when('/editor/:workspace/:project/:path*', {
             templateUrl: appResourceRoot + 'editor-app/editor.html',
             controller: 'EditorController'
         })


### PR DESCRIPTION
Currently, if you try to open a `bpmn` file not from the root of a Dirigible project, nothing happens. 
This PR handles workspace project paths for nested `bpmn` files.